### PR TITLE
Include `--quiet` flag in cloud example

### DIFF
--- a/cloud-example/.circleci/config.yml
+++ b/cloud-example/.circleci/config.yml
@@ -6,4 +6,4 @@ workflows:
     jobs:
      - grafana/k6:
           cloud: true
-          script: loadtests/performance-test.js
+          script: loadtests/performance-test.js --quiet


### PR DESCRIPTION
When running cloud tests in CircleCI, the orb will clobber `stdout` for the job with a huge amount of progress updates. 

These updates are intended to first clear a buffer so that they are shown as a progress bar, but in CircleCi they are continuously appended  meaning the output becomes unreadable / unhelpful and very quickly reaches the maximum allowed output size. 

Additionally, neither the `--out` flag nor the option to export a `handleSummary` method are supported by k6 when using the cloud option. While it would be preferable to have these available, in the meantime it's at least possible to suppress the unwanted output with the `--quiet` flag but it took a lot of trial and error with the available flags / output redirection to find the best available solution - so suggest including this in the default cloud example.